### PR TITLE
add github link

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,7 @@
 [{
   "Name": "monokai-dark",
   "Description": "A dark monokai colorscheme for micro",
+  "Website": "https://github.com/Theodus/micro-monokai-dark",
   "Tags": ["colorscheme"],
   "Versions": [
     {


### PR DESCRIPTION
This adds the github link so that the repo can be found from the [plugin page](https://micro-editor.github.io/plugins.html).